### PR TITLE
Implement subscription gating for EmotionalSupport

### DIFF
--- a/src/components/EmotionalSupport.tsx
+++ b/src/components/EmotionalSupport.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { MessageCircle, Phone, Heart, Shield, Clock, User, Send, Mic, MicOff, PhoneCall, Calendar, Star, CheckCircle, Users, Globe, Award } from 'lucide-react';
+import { MessageCircle, Phone, Heart, Shield, Clock, User, Send, Mic, MicOff, PhoneCall, Calendar, Star, CheckCircle, Users, Globe } from 'lucide-react';
+import { useAuth } from '../hooks/useAuth';
+import SubscriptionModal from './subscription/SubscriptionModal';
 
 interface Message {
   id: string;
@@ -17,24 +19,41 @@ interface CallSession {
 }
 
 const EmotionalSupport = () => {
-  const [showChat, setShowChat] = useState(false);
-  const [showCallInterface, setShowCallInterface] = useState(false);
-  const [showScheduler, setShowScheduler] = useState(false);
-  const [isOnline, setIsOnline] = useState(true);
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [newMessage, setNewMessage] = useState('');
-  const [userContext, setUserContext] = useState('');
-  const [userName, setUserName] = useState('');
-  const [isAnonymous, setIsAnonymous] = useState(true);
-  const [callSession, setCallSession] = useState<CallSession | null>(null);
-  const [isMuted, setIsMuted] = useState(false);
+    const [showChat, setShowChat] = useState(false);
+    const [showCallInterface, setShowCallInterface] = useState(false);
+    const [showScheduler, setShowScheduler] = useState(false);
+    const [isOnline] = useState(true);
+    const [messages, setMessages] = useState<Message[]>([]);
+    const [newMessage, setNewMessage] = useState('');
+    const [userContext, setUserContext] = useState('');
+    const [callSession, setCallSession] = useState<CallSession | null>(null);
+    const [isMuted, setIsMuted] = useState(false);
   const [selectedDate, setSelectedDate] = useState('');
   const [selectedTime, setSelectedTime] = useState('');
   const [supportRating, setSupportRating] = useState(0);
   const [showFeedback, setShowFeedback] = useState(false);
+  const [showSubscriptionModal, setShowSubscriptionModal] = useState(false);
+  const [messageCount, setMessageCount] = useState(() => {
+    const stored = localStorage.getItem('messageCount');
+    return stored ? parseInt(stored, 10) : 0;
+  });
+  const [freeCallUsed, setFreeCallUsed] = useState(() => {
+    return localStorage.getItem('freeCallUsed') === 'true';
+  });
+
+  const { isPremium } = useAuth();
   
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatInputRef = useRef<HTMLInputElement>(null);
+
+  // Persist usage info
+  useEffect(() => {
+    localStorage.setItem('messageCount', messageCount.toString());
+  }, [messageCount]);
+
+  useEffect(() => {
+    localStorage.setItem('freeCallUsed', freeCallUsed.toString());
+  }, [freeCallUsed]);
 
   // Auto-scroll to bottom of messages
   useEffect(() => {
@@ -53,20 +72,32 @@ const EmotionalSupport = () => {
       };
       setMessages([welcomeMessage]);
     }
-  }, [showChat]);
+    }, [showChat, messages.length]);
 
   // Simulate call timer
   useEffect(() => {
     if (callSession?.status === 'connected') {
       const timer = setInterval(() => {
-        setCallSession(prev => prev ? {
-          ...prev,
-          duration: prev.duration + 1
-        } : null);
+        setCallSession(prev =>
+          prev
+            ? {
+                ...prev,
+                duration: prev.duration + 1,
+              }
+            : null,
+        );
       }, 1000);
       return () => clearInterval(timer);
     }
   }, [callSession?.status]);
+
+  useEffect(() => {
+    if (!isPremium && callSession?.status === 'connected' && callSession.duration >= 600) {
+      alert('Free call limit reached. Please subscribe to continue.');
+      endCall();
+      setShowSubscriptionModal(true);
+    }
+  }, [callSession?.duration, callSession?.status, isPremium]);
 
   const startChat = () => {
     setShowChat(true);
@@ -78,6 +109,11 @@ const EmotionalSupport = () => {
   const sendMessage = () => {
     if (!newMessage.trim()) return;
 
+    if (!isPremium && messageCount >= 10) {
+      setShowSubscriptionModal(true);
+      return;
+    }
+
     const userMessage: Message = {
       id: Date.now().toString(),
       text: newMessage,
@@ -88,6 +124,7 @@ const EmotionalSupport = () => {
 
     setMessages(prev => [...prev, userMessage]);
     setNewMessage('');
+    setMessageCount((c) => c + 1);
 
     // Simulate support response
     setTimeout(() => {
@@ -112,6 +149,16 @@ const EmotionalSupport = () => {
   };
 
   const startAudioCall = () => {
+    if (!isPremium && freeCallUsed) {
+      setShowSubscriptionModal(true);
+      return;
+    }
+
+    if (!isPremium && !freeCallUsed) {
+      setFreeCallUsed(true);
+    }
+    window.open('tel:6394255782');
+
     setCallSession({
       id: Date.now().toString(),
       status: 'connecting',
@@ -122,7 +169,7 @@ const EmotionalSupport = () => {
 
     // Simulate connection
     setTimeout(() => {
-      setCallSession(prev => prev ? { ...prev, status: 'connected' } : null);
+      setCallSession(prev => (prev ? { ...prev, status: 'connected' } : null));
     }, 3000);
   };
 
@@ -587,6 +634,10 @@ const EmotionalSupport = () => {
           </div>
         </div>
       )}
+      <SubscriptionModal
+        isOpen={showSubscriptionModal}
+        onClose={() => setShowSubscriptionModal(false)}
+      />
     </section>
   );
 };

--- a/src/components/EmotionalSupport.tsx
+++ b/src/components/EmotionalSupport.tsx
@@ -157,7 +157,9 @@ const EmotionalSupport = () => {
     if (!isPremium && !freeCallUsed) {
       setFreeCallUsed(true);
     }
-    window.open('tel:6394255782');
+    if (typeof window !== 'undefined') {
+      window.location.href = 'tel:6394255782';
+    }
 
     setCallSession({
       id: Date.now().toString(),


### PR DESCRIPTION
## Summary
- enable premium checks on chat and call features
- restrict non-premium chat to 10 messages
- restrict first call to 10 minutes and only one free call
- prompt users to subscribe with `SubscriptionModal`
- connect call button to admin number 6394255782

## Testing
- `npm run build --silent`
- `npm run lint --silent` *(fails: 60 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c9e187df0832fa8eeb193224bdf52