### PR TITLE
feat: add simple Google and password login

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -24,7 +24,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialMode = 'l
   const [error, setError] = useState('');
   const [otpSent, setOtpSent] = useState(false);
 
-  const { signIn, signUp } = useAuth();
+  const { signIn, signUp, signInWithGoogle } = useAuth();
 
   if (!isOpen) return null;
 
@@ -59,9 +59,14 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialMode = 'l
     }
   };
 
-  const handleGoogleLogin = () => {
-    // Google OAuth integration would go here
-    console.log('Google login clicked');
+  const handleGoogleLogin = async () => {
+    try {
+      const { error } = await signInWithGoogle();
+      if (error) throw error;
+      onClose();
+    } catch (err: any) {
+      setError(err.message || 'Google login failed');
+    }
   };
 
   const handleTrueCallerLogin = () => {

--- a/src/components/auth/AuthSystem.tsx
+++ b/src/components/auth/AuthSystem.tsx
@@ -40,7 +40,7 @@ const AuthSystem: React.FC<AuthSystemProps> = ({ isOpen, onClose, onLoginSuccess
     language: 'en'
   });
 
-  const { signIn, signUp } = useAuth();
+  const { signIn, signUp, signInWithGoogle } = useAuth();
 
   const languages = [
     { code: 'en', name: 'English', native: 'English' },
@@ -92,17 +92,8 @@ const AuthSystem: React.FC<AuthSystemProps> = ({ isOpen, onClose, onLoginSuccess
   const handleGoogleLogin = async () => {
     setLoading(true);
     try {
-      // Simulate Google OAuth flow
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      // In real implementation, use Google OAuth 2.0
-      const googleUser = {
-        email: 'user@gmail.com',
-        name: 'John Doe',
-        picture: 'https://images.pexels.com/photos/1051838/pexels-photo-1051838.jpeg'
-      };
-      
-      console.log('Google login successful:', googleUser);
+      const { error } = await signInWithGoogle();
+      if (error) throw error;
       onLoginSuccess();
       onClose();
     } catch (err) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -58,6 +58,13 @@ export function useAuth() {
     return { data, error };
   };
 
+  const signInWithGoogle = async () => {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+    });
+    return { data, error };
+  };
+
   const signOut = async () => {
     const { error } = await authAPI.signOut();
     if (!error) {
@@ -83,6 +90,7 @@ export function useAuth() {
     loading,
     signUp,
     signIn,
+    signInWithGoogle,
     signOut,
     updateProfile,
     isAuthenticated: !!user,


### PR DESCRIPTION
## Summary
- add Supabase helper for Google OAuth sign-in
- connect AuthSystem and AuthModal to use new Google login

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6891dffdd550832fbeddb2031f036448