### PR TITLE
feat: allow admin to create blog posts

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { blogAPI } from '../../lib/api';
 
 interface ChatMessage {
   id: number;
@@ -12,10 +13,36 @@ const AdminDashboard: React.FC = () => {
   ]);
   const [reply, setReply] = useState('');
 
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [posting, setPosting] = useState(false);
+  const [postMessage, setPostMessage] = useState<string | null>(null);
+
   const sendReply = () => {
     if (!reply.trim()) return;
     setMessages([...messages, { id: Date.now(), from: 'admin', message: reply }]);
     setReply('');
+  };
+
+  const createPost = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title || !content || !imageFile) {
+      setPostMessage('All fields are required');
+      return;
+    }
+
+    setPosting(true);
+    const { error } = await blogAPI.createBlogPost({ title, content, image: imageFile });
+    if (error) {
+      setPostMessage(error.message);
+    } else {
+      setPostMessage('Blog post published');
+      setTitle('');
+      setContent('');
+      setImageFile(null);
+    }
+    setPosting(false);
   };
 
   return (
@@ -39,6 +66,40 @@ const AdminDashboard: React.FC = () => {
           <p className="text-sm text-stone-500">Pages Viewed</p>
           <p className="text-2xl font-bold">0</p>
         </div>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h2 className="text-lg font-medium mb-4">Create Blog Post</h2>
+        <form onSubmit={createPost} className="space-y-3">
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full border border-stone-300 rounded p-2"
+            placeholder="Title"
+          />
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            className="w-full border border-stone-300 rounded p-2"
+            placeholder="Content"
+            rows={4}
+          />
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setImageFile(e.target.files ? e.target.files[0] : null)}
+          />
+          <button
+            type="submit"
+            disabled={posting}
+            className="px-4 py-2 bg-stone-800 text-white rounded"
+          >
+            {posting ? 'Posting...' : 'Post Blog'}
+          </button>
+        </form>
+        {postMessage && (
+          <p className="text-sm mt-2">{postMessage}</p>
+        )}
       </div>
 
       <div className="bg-white p-4 rounded-lg shadow">


### PR DESCRIPTION
## Summary
- allow admin dashboard to create blog posts with image uploads
- add supabase API helper for uploading image and inserting blog post

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a586a5e674832fa0ff4ec37234464b